### PR TITLE
feat(backend): add entity-specific date methods back and make getDate…

### DIFF
--- a/server/src/main/java/hagimetaceinture/server/event/Event.java
+++ b/server/src/main/java/hagimetaceinture/server/event/Event.java
@@ -29,11 +29,11 @@ public abstract class Event {
     this.id = id;
   }
 
-  public Date getDate() {
+  protected Date getDate() {
     return date;
   }
 
-  public void setDate(Date date) {
+  protected void setDate(Date date) {
     this.date = date;
   }
 

--- a/server/src/main/java/hagimetaceinture/server/meeting/Meeting.java
+++ b/server/src/main/java/hagimetaceinture/server/meeting/Meeting.java
@@ -38,6 +38,14 @@ public class Meeting extends Event {
     return guests;
   }
 
+  public Date getMeetingDate() {
+    return this.getDate();
+  }
+
+  public void setMeetingDate(Date date) {
+    this.setDate(date);
+  }
+
   public void setGuests(Collection<Member> guests) {
     this.guests = guests;
   }

--- a/server/src/main/java/hagimetaceinture/server/race/Race.java
+++ b/server/src/main/java/hagimetaceinture/server/race/Race.java
@@ -59,4 +59,12 @@ public class Race extends Event {
         + vehiculeType + ", participants=" + participants + "]";
   }
 
+  public Date getCreationDate() {
+    return this.getDate();
+  }
+
+  public void setCreationDate(Date date) {
+    this.setDate(date);
+  }
+
 }

--- a/server/src/main/java/hagimetaceinture/server/sponsor/Sponsor.java
+++ b/server/src/main/java/hagimetaceinture/server/sponsor/Sponsor.java
@@ -76,9 +76,4 @@ public class Sponsor extends Event {
         + ", fundationDate=" + getDate() + "]";
   }
 
-  @Override
-  public java.sql.Date getDate() {
-    return getFundationDate();
-  }
-
 }

--- a/server/src/main/java/hagimetaceinture/server/vehicule/Vehicule.java
+++ b/server/src/main/java/hagimetaceinture/server/vehicule/Vehicule.java
@@ -2,43 +2,28 @@ package hagimetaceinture.server.vehicule;
 
 import java.sql.Date;
 
+import hagimetaceinture.server.event.Event;
 import hagimetaceinture.server.member.Member;
 import hagimetaceinture.server.vehiculetype.VehiculeType;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 
 @Entity
-public class Vehicule {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long idVehicule;
+public class Vehicule extends Event {
 
-    @ManyToOne
-    private VehiculeType vehiculeType;
+	@ManyToOne
+	private VehiculeType vehiculeType;
 
-    private String branch;
+	private String branch;
 
-    private String model;
+	private String model;
 
-    private String licensePlate;
+	private String licensePlate;
 
-    @ManyToOne
-    private Member owner;
-
-    private Date firstLicensePlate;
+	@ManyToOne
+	private Member owner;
 
 	public Vehicule() {
-    }
-
-    public long getIdVehicule() {
-		return idVehicule;
-	}
-
-	public void setIdVehicule(long idVehicule) {
-		this.idVehicule = idVehicule;
 	}
 
 	public String getBranch() {
@@ -66,34 +51,34 @@ public class Vehicule {
 	}
 
 	public Date getFirstLicensePlate() {
-		return firstLicensePlate;
+		return getDate();
 	}
 
 	public void setFirstLicensePlate(Date firstLicensePlate) {
-		this.firstLicensePlate = firstLicensePlate;
+		setDate(firstLicensePlate);
 	}
 
-    public VehiculeType getVehiculeType() {
-        return vehiculeType;
-    }
+	public VehiculeType getVehiculeType() {
+		return vehiculeType;
+	}
 
-    public void setVehiculeType(VehiculeType vehiculeType) {
-        this.vehiculeType = vehiculeType;
-    }
+	public void setVehiculeType(VehiculeType vehiculeType) {
+		this.vehiculeType = vehiculeType;
+	}
 
-    @Override
-    public String toString() {
-        return "Vehicule [idVehicule=" + idVehicule + ", vehiculeType=" + vehiculeType + ", branch=" + branch
-                + ", model=" + model + ", licensePlate=" + licensePlate + ", owner=" + owner + ", firstLicensePlate="
-                + firstLicensePlate + "]";
-    }
+	@Override
+	public String toString() {
+		return "Vehicule [idVehicule=" + getId() + ", vehiculeType=" + vehiculeType + ", branch=" + branch
+				+ ", model=" + model + ", licensePlate=" + licensePlate + ", owner=" + owner + ", firstLicensePlate="
+				+ getFirstLicensePlate() + "]";
+	}
 
-    public Member getOwner() {
-        return owner;
-    }
+	public Member getOwner() {
+		return owner;
+	}
 
-    public void setOwner(Member owner) {
-        this.owner = owner;
-    }
+	public void setOwner(Member owner) {
+		this.owner = owner;
+	}
 
 }

--- a/server/src/test/java/hagimetaceinture/server/FacadeTest.java
+++ b/server/src/test/java/hagimetaceinture/server/FacadeTest.java
@@ -27,9 +27,11 @@ class FacadeTest {
   @Autowired
   private MockMvc mockMvc;
 
+  @SuppressWarnings("removal")
   @MockBean
   private CircuitRepository circuitRepo;
 
+  @SuppressWarnings("removal")
   @MockBean
   private EventRepository eventRepo;
 


### PR DESCRIPTION
# Things done

- Made `date` getter and setter private in `Event` 
- Brought subclass-specific date getters and setters

# Why
To keep the inheritance and the ability to collect `Event` subclasses in calendar while keeping the semantics or their Date getters and setters (`getCreationDate` is better than `getDate`)

The getter and setter from `Event` are actually useless since we'll need to cast the classes anyway (to be nicely displayed)